### PR TITLE
register_blosc: optional date/version output 

### DIFF
--- a/src/blosc_filter.c
+++ b/src/blosc_filter.c
@@ -57,10 +57,10 @@ int register_blosc(char **version, char **date){
     if(retval<0){
         PUSH_ERR("register_blosc", H5E_CANTREGISTER, "Can't register Blosc filter");
     }
-	if (version != NULL && date != NULL) {
-    	*version = strdup(BLOSC_VERSION_STRING);
-    	*date = strdup(BLOSC_VERSION_DATE);
-	}
+    if (version != NULL && date != NULL) {
+        *version = strdup(BLOSC_VERSION_STRING);
+        *date = strdup(BLOSC_VERSION_DATE);
+    }
     return 1; /* lib is available */
 }
 

--- a/src/blosc_filter.c
+++ b/src/blosc_filter.c
@@ -57,8 +57,10 @@ int register_blosc(char **version, char **date){
     if(retval<0){
         PUSH_ERR("register_blosc", H5E_CANTREGISTER, "Can't register Blosc filter");
     }
-    *version = strdup(BLOSC_VERSION_STRING);
-    *date = strdup(BLOSC_VERSION_DATE);
+	if (version != NULL && date != NULL) {
+    	*version = strdup(BLOSC_VERSION_STRING);
+    	*date = strdup(BLOSC_VERSION_DATE);
+	}
     return 1; /* lib is available */
 }
 


### PR DESCRIPTION
This PR lets one `register_blosc` without obtaining the current version and date by supplying NULL to the output pointers.
