### PR TITLE
Cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ message("BLOSC_INSTALL_DIR='${BLOSC_INSTALL_DIR}'")
 message("BLOSC_CMAKE_ARGS='${BLOSC_CMAKE_ARGS}'")
 message("GIT_EXECUTABLE='${GIT_EXECUTABLE}'")
 
-ExternalProject_Add(blosc
+ExternalProject_Add(project_blosc
   PREFIX ${BLOSC_PREFIX}
   GIT_REPOSITORY https://github.com/Blosc/c-blosc.git
   INSTALL_DIR ${BLOSC_INSTALL_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ option(BUILD_TESTS
 
 option(BUILD_PLUGIN
     "Build dynamically loadable plugin for HDF5 version > 1.8.11" ON)
+if(BUILD_PLUGIN)
+    set(PLUGIN_INSTALL_PATH "/usr/local/hdf5/lib/plugin" CACHE PATH 
+      "Where to install the dynamic HDF5-plugin")
+endif(BUILD_PLUGIN)
 
 set(BLOSC_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/blosc")
 set(BLOSC_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/blosc")
@@ -62,6 +66,8 @@ if(BUILD_PLUGIN)
     set_target_properties(
       blosc_plugin_shared PROPERTIES OUTPUT_NAME H5Zblosc)
     target_link_libraries(blosc_plugin_shared blosc_shared ${HDF5_LIBRARIES})
+
+    install(TARGETS blosc_plugin_shared DESTINATION ${PLUGIN_INSTALL_PATH} COMPONENT HDF5_FILTER_DEV)
 endif(BUILD_PLUGIN)
 
 # install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ include(ExternalProject)
 option(BUILD_TESTS
     "Build test programs form the blosc filter" ON)
 
+option(BUILD_PLUGIN
+    "Build dynamically loadable plugin for HDF5 version > 1.8.11" ON)
+
 set(BLOSC_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/blosc")
 set(BLOSC_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/blosc")
 set(BLOSC_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${BLOSC_INSTALL_DIR})
@@ -25,6 +28,7 @@ ExternalProject_Add(project_blosc
 
 # sources
 set(SOURCES src/blosc_filter.c)
+set(PLUGIN_SOURCES src/blosc_filter.c src/blosc_plugin.c )
 
 # dependencies
 if(MSVC)
@@ -52,6 +56,13 @@ add_library(blosc_filter_shared SHARED ${SOURCES})
 set_target_properties(
   blosc_filter_shared PROPERTIES OUTPUT_NAME blosc_filter)
 target_link_libraries(blosc_filter_shared blosc_shared ${HDF5_LIBRARIES})
+
+if(BUILD_PLUGIN)
+    add_library(blosc_plugin_shared SHARED ${PLUGIN_SOURCES})
+    set_target_properties(
+      blosc_plugin_shared PROPERTIES OUTPUT_NAME H5Zblosc)
+    target_link_libraries(blosc_plugin_shared blosc_shared ${HDF5_LIBRARIES})
+endif(BUILD_PLUGIN)
 
 # install
 install(FILES src/blosc_filter.h DESTINATION include COMPONENT HDF5_FILTER_DEV)


### PR DESCRIPTION
This PR fix CMake such that the Blosc library is fetched and compiled automatically (as intended, just a typo fixed). It also adds the dynamic HDF5 plugin (libH5Zblosc) as a target. This is enabled by default, but can optionally be disabled. This PR close issue #3.