### PR TITLE
Allow for HDF5_ROOT and set blosc tag to main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.10)
+cmake_policy(SET CMP0074 NEW)
 project(blosc_hdf5)
 include(ExternalProject)
 
@@ -25,6 +26,7 @@ message("GIT_EXECUTABLE='${GIT_EXECUTABLE}'")
 ExternalProject_Add(project_blosc
   PREFIX ${BLOSC_PREFIX}
   GIT_REPOSITORY https://github.com/Blosc/c-blosc.git
+  GIT_TAG main
   INSTALL_DIR ${BLOSC_INSTALL_DIR}
   CMAKE_ARGS ${BLOSC_CMAKE_ARGS}
 )


### PR DESCRIPTION
* [CMP0074](https://cmake.org/cmake/help/latest/policy/CMP0074.html) allows `HDF5_ROOT` to be set for finding the HDF5 binaries.

* The primary branch for Blosc has changed to `main`.