### PR TITLE
Fix `GIT_TAG` for `ExternalProject_Add` and two warnings in compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(BUILD_TESTS
 option(BUILD_PLUGIN
     "Build dynamically loadable plugin for HDF5 version > 1.8.11" ON)
 if(BUILD_PLUGIN)
-    set(PLUGIN_INSTALL_PATH "/usr/local/hdf5/lib/plugin" CACHE PATH 
+    set(PLUGIN_INSTALL_PATH "/usr/local/hdf5/lib/plugin" CACHE PATH
       "Where to install the dynamic HDF5-plugin")
 endif(BUILD_PLUGIN)
 
@@ -25,6 +25,7 @@ message("GIT_EXECUTABLE='${GIT_EXECUTABLE}'")
 ExternalProject_Add(project_blosc
   PREFIX ${BLOSC_PREFIX}
   GIT_REPOSITORY https://github.com/Blosc/c-blosc.git
+  GIT_TAG main
   INSTALL_DIR ${BLOSC_INSTALL_DIR}
   CMAKE_ARGS ${BLOSC_CMAKE_ARGS}
 )

--- a/src/blosc_filter.c
+++ b/src/blosc_filter.c
@@ -155,8 +155,8 @@ size_t blosc_filter(unsigned flags, size_t cd_nelmts,
   int doshuffle = 1;             /* Shuffle default */
   int compcode;                  /* Blosc compressor */
   int code;
-  char* compname = "blosclz";    /* The compressor by default */
-  char* complist;
+  const char* compname = "blosclz";    /* The compressor by default */
+  const char* complist;
   char errmsg[256];
 
   /* Filter params that are always set */


### PR DESCRIPTION
`Blosc/c-blosc` has switched to use `main` as the default branch instead of `master`, yet `ExternalProject_Add` still treat `master` as the default branch, which will cause trouble during the building process. This PR fixes this issue.

The functions `blosc_list_compressors()` and `blosc_compcode_to_compname()` also required `const` pointers as inputs. This PR also fixes this issue.