### PR TITLE
Fix build on systems where the libdir is lib64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.10)
 cmake_policy(SET CMP0074 NEW)
 project(blosc_hdf5)
 include(ExternalProject)
+include(GNUInstallDirs)
 
 # options
 option(BUILD_TESTS
@@ -54,7 +55,7 @@ include_directories(${HDF5_INCLUDE_DIRS})
 
 # add blosc libraries
 add_library(blosc_shared SHARED IMPORTED)
-set_property(TARGET blosc_shared PROPERTY IMPORTED_LOCATION ${BLOSC_INSTALL_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}blosc${CMAKE_SHARED_LIBRARY_SUFFIX})
+set_property(TARGET blosc_shared PROPERTY IMPORTED_LOCATION ${BLOSC_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}blosc${CMAKE_SHARED_LIBRARY_SUFFIX})
 add_dependencies(blosc_shared project_blosc)
 include_directories(${BLOSC_INSTALL_DIR}/include)
 


### PR DESCRIPTION
Following the installation instructions, when I run `make`, the build stops with the error:
```
[ 60%] Building C object CMakeFiles/blosc_filter_shared.dir/src/blosc_filter.c.o
make[2]: *** No rule to make target 'blosc/lib/libblosc.so', needed by 'libblosc_filter.so'.  Stop.
make[1]: *** [CMakeFiles/Makefile2:115: CMakeFiles/blosc_filter_shared.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

The cause seems to be that blosc is installing libraries to `lib64`, while hdf5-blosc looks for them in the hard-coded `lib` directory. Following https://github.com/Blosc/c-blosc/pull/328, I think the fix is just to use `GnuInstallDirs` to find the name of the libdir.