### PR TITLE
Move Fletcher32 filter to last position in example source

### DIFF
--- a/src/example.c
+++ b/src/example.c
@@ -74,12 +74,6 @@ int main(){
     r = H5Pset_chunk(plist, 3, chunkshape);
     if(r<0) goto failed;
 
-    /* Using the blosc filter in combination with other ones also works */
-    /*
-    r = H5Pset_fletcher32(plist);
-    if(r<0) goto failed;
-    */
-
     /* This is the easiest way to call Blosc with default values: 5
      for BloscLZ and shuffle active. */
     /* r = H5Pset_filter(plist, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 0, NULL); */
@@ -94,6 +88,13 @@ int main(){
     r = H5Pset_filter(plist, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cd_values);
 
     if(r<0) goto failed;
+
+    /* Using the blosc filter in combination with other ones also works
+     (if they change data structure, they should come last) */
+    /*
+    r = H5Pset_fletcher32(plist);
+    if(r<0) goto failed;
+    */
 
 #if H5_USE_16_API
     dset = H5Dcreate(fid, "dset", H5T_NATIVE_FLOAT, sid, plist);


### PR DESCRIPTION
By performing and adding the checksum after compression, the compressor doesn't need to worry about the checksum being there (nor does decompression). Of course, this means that enabling Fletcher32 adds 4 bytes to each chunk, but compressing them as part of the data doesn't make much sense either.

See <https://github.com/PyTables/PyTables/pull/1191> for extra context.